### PR TITLE
Update groups management

### DIFF
--- a/login-authentication-iam-web/bnd.bnd
+++ b/login-authentication-iam-web/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName: com.liferay.login.authentication.iam.web
-Bundle-Version: 1.0.1
+Bundle-Version: 1.0.2
 Bundle-Name: Login Authentication IAM Web
 Bundle-Description: Login extension for IAM authentication
 Bundle-Copyright: Copyright 2016, INFN - INDIGO-DataCloud

--- a/portal-security-sso-iam/bnd.bnd
+++ b/portal-security-sso-iam/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName: com.liferay.portal.security.sso.iam
-Bundle-Version: 1.0.1
+Bundle-Version: 1.0.2
 Bundle-Name: Liferay Portal Security SSO IAM
 Bundle-Description: SSO module for INDIGO-DC IAM service. The IAM service is integrated using \
         the OpenID Connect protocol

--- a/portal-security-sso-iam/src/main/java/com/liferay/portal/security/sso/iam/internal/IAMImpl.java
+++ b/portal-security-sso-iam/src/main/java/com/liferay/portal/security/sso/iam/internal/IAMImpl.java
@@ -572,10 +572,9 @@ public class IAMImpl implements IAM {
             return null;
         }
         List<Long> groupIds = new LinkedList<>();
-        for (int i = 0; i < listGroups.size(); i++) {
-            JSONObject gr = (JSONObject) listGroups.get(i);
-            String groupName = IAMConfigurationKeys.GROUP_PREFIX + gr.get(
-                    "name").toString();
+        for (Object gr: listGroups) {
+            String groupName = IAMConfigurationKeys.GROUP_PREFIX
+                    + gr.toString();
 
             UserGroup lifeUG = null;
             ServiceContext serviceContext = new ServiceContext();

--- a/portal-settings-authentication-iam-web/bnd.bnd
+++ b/portal-settings-authentication-iam-web/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName: com.liferay.portal.settings.authentication.iam.web
-Bundle-Version: 1.0.1
+Bundle-Version: 1.0.2
 Bundle-Name: Liferay Portal Settings Authentication IAM Web
 Bundle-Description: Liferay Portal Settings Authentication Web interface for INDIGO-DC IAM service. \
 	This make use of OpenID Connect protocol for the authentication

--- a/service-iam-token/service-iam-token-api/bnd.bnd
+++ b/service-iam-token/service-iam-token-api/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName: com.liferay.portal.security.sso.iam.api
-Bundle-Version: 1.0.1
+Bundle-Version: 1.0.2
 Bundle-Name: IAM Tokens Manager API
 Bundle-Description: Remote API to manage tokens released by IAM service and allow their use to portlet and other application
 Bundle-Copyright: Copyright 2016, INFN - INDIGO-DataCloud

--- a/service-iam-token/service-iam-token-service/bnd.bnd
+++ b/service-iam-token/service-iam-token-service/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName: com.liferay.portal.security.sso.iam.service
-Bundle-Version: 1.0.1
+Bundle-Version: 1.0.2
 Bundle-Name: IAM Tokens Manager Service
 Bundle-Description: Manages token released by IAM service and allows their use to portlet and other application
 Bundle-Copyright: Copyright 2016, INFN - INDIGO-DataCloud


### PR DESCRIPTION
Follow the new IAM groups specification:
- Groups are now encoded in the JSON returned by the IAM /userinfo
  endpoint as an array of group names, i.e.:
  
  ...
  "groups": [
    "Users",
    "Developers"
  ]

From IAM >= v0.4.0.rc0
